### PR TITLE
fix for Cannot read property 'cssExtension' of undefined and incorrect css path in App.js

### DIFF
--- a/generators/cssGen.js
+++ b/generators/cssGen.js
@@ -35,7 +35,7 @@ var generateCSS = function(fileName, fileType, currentWDir) {
                 }
               });
             } else {
-              autoImportCSS(srcAppJsFilePath, cssFilePath, cssFileName, 'src')
+              autoImportCSS(srcAppJsFilePath, cssFilePath, cssFileName, 'src', projectsMikeyJson)
             }
           });
         } else {
@@ -56,7 +56,8 @@ var autoImportCSS = function(filePath, cssFilePath, cssFileName, clientOrSrc, pr
     if (clientOrSrc === 'client') {
       newData = readFilePath.replace(regExpCSS, `${replaceText}import '.${cssFilePath}';\n` );
     } else {
-      newData = readFilePath.replace(regExpCSS, `${replaceText}import '${cssFilePath}';\n` );
+      var cssLocation = cssFilePath.replace(/([^\/]*\/){2}/, './');
+      newData = readFilePath.replace(regExpCSS, `${replaceText}import '${cssLocation}';\n` );
     }
     fs.writeFileSync(filePath, newData, 'utf8');
     console.log('Successfuly imported ' + colors.yellow(cssFileName + '.' + projectsMikeyJson.cssExtension) + ' in ' + colors.yellow(filePath.toString()));


### PR DESCRIPTION
This corrects the following error

![before](https://cloud.githubusercontent.com/assets/4191428/23473889/ac7668ca-fea9-11e6-8b98-a7bf2042a38a.png)

and also changes css location in App.js from './scss/css' to './css' as the css is in same directory as the component
